### PR TITLE
adding deb-security-manifest

### DIFF
--- a/0.1.0/rockcraft.yaml
+++ b/0.1.0/rockcraft.yaml
@@ -24,3 +24,15 @@ parts:
     source-tag: "v0.1.0"
     build-snaps:
       - go/1.23/stable
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - metrics-proxy
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
## Description

Adding required parts to onboard the rock in oci-factory, see [guidelines](https://github.com/canonical/oci-factory/blob/main/IMAGE_MAINTAINER_AGREEMENT.md#enable-security-monitoring)