### PR TITLE
Fix args

### DIFF
--- a/0.1.0/rockcraft.yaml
+++ b/0.1.0/rockcraft.yaml
@@ -12,7 +12,7 @@ services:
   metrics-proxy:
     override: replace
     startup: enabled
-    command: metrics-proxy [ args ]
+    command: metrics-proxy [ ]
 
 entrypoint-service: metrics-proxy
 


### PR DESCRIPTION
The current way of passing args will call "args" if nothing is passed. An empty bracket will properly pass nothing.
