### PR TITLE
switch `env` to be a kgoss `env`

### DIFF
--- a/0.1.1/rockcraft.yaml
+++ b/0.1.1/rockcraft.yaml
@@ -12,9 +12,6 @@ services:
   metrics-proxy:
     override: replace
     startup: enabled
-    environment:
-      POD_LABEL_SELECTOR: foo=bar
-    command: metrics-proxy [ args ]
 
 parts:
   metrics-proxy:

--- a/0.1.1/rockcraft.yaml
+++ b/0.1.1/rockcraft.yaml
@@ -12,6 +12,7 @@ services:
   metrics-proxy:
     override: replace
     startup: enabled
+    command: metrics-proxy
 
 parts:
   metrics-proxy:

--- a/justfile
+++ b/justfile
@@ -30,4 +30,4 @@ run version=latest_version: (push-to-registry version)
 
 # Test the rock with `kgoss`
 test version=latest_version: (push-to-registry version)
-  GOSS_OPTS="--retry-timeout 60s" kgoss run -i localhost:32000/${rock_name}-dev:${version}
+  GOSS_OPTS="--retry-timeout 60s" kgoss run -i localhost:32000/${rock_name}-dev:${version} -e "POD_LABEL_SELECTOR=foo=bar"


### PR DESCRIPTION
### Issue
The rock always starts with a default environment variable `POD_LABEL_SELECTOR: foo=bar`. While this can be overridden using `docker` or `Kubernetes`, having a default environment variable that influences the rock's behavior isn't ideal for the user experience.

### Solution
Update the rock to run only the binary by default, and specify any required environment variables for testing explicitly as `kgoss` environments