### PR TITLE
chore: rollback baseimage

### DIFF
--- a/0.1.1/rockcraft.yaml
+++ b/0.1.1/rockcraft.yaml
@@ -4,7 +4,7 @@ description: A metrics proxy server that aggregates Prometheus metrics from Kube
 license: Apache-2.0
 
 version: "0.1.1"
-base: "ubuntu@26.04"
+base: "ubuntu@24.04"
 platforms:
   amd64:
 


### PR DESCRIPTION
rollsback v0.1.1 to ubuntu 2404 baseimage
